### PR TITLE
added host-specific queues and now host-wide delay policies can be enforced

### DIFF
--- a/src/itsy/core.clj
+++ b/src/itsy/core.clj
@@ -150,7 +150,8 @@
         (trace :running? (get @(-> config :state :worker-canaries) tid))
         (let [state (:state config)
               limit-reached (and (pos? (:url-limit config))
-                                 (= @(:url-count state) (:url-limit config)))]
+                                 (>= @(:url-count state) (:url-limit config)))]
+          (trace :count @(:url-count state))
           (when-not (get @(:worker-canaries state) tid)
             (debug "my canary has died, terminating myself"))
           (when limit-reached

--- a/src/itsy/queues.clj
+++ b/src/itsy/queues.clj
@@ -31,9 +31,8 @@ We expect a timestamp to be milliseconds since epoch"
   (let [processed-url (url a-url)
         the-host      (-> processed-url :host)]
     (if-let [host-queue (@*host-urls-queue* the-host)]
-      (do (.put host-queue {:url   a-url
-                            :count (-> config :state :url-count)})
-          (swap! (-> config :state :url-count) inc))
+      (.put host-queue {:url   a-url
+                        :count (-> config :state :url-count)})
       (do
         (setup-new-host the-host)
         (recur config a-url)))))


### PR DESCRIPTION
I have added a default-delay-policy (wait 3 seconds before next request). And now, a ready queue is used to look @ the next set of URLs. Increments are done once the handler does what it needs to with the body
