### PR TITLE
fix readme example for es-handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,11 @@ Usage:
                        :number_of_replicas 0}}})
 
 ;; If the ES index doesn't exist, make-es-handler will create it when called.
-(defn es-handler [] (make-es-handler {:es-url "http://localhost:9200/"
-                                      :es-index "crawl"
-                                      :es-type "page"
-                                      :es-index-settings index-settings
-                                      :http-opts {}}))
+(def es-handler (make-es-handler {:es-url "http://localhost:9200/"
+                                  :es-index "crawl"
+                                  :es-type "page"
+                                  :es-index-settings index-settings
+                                  :http-opts {}}))
 
 (def c (crawl {:url "http://example.com" :handler es-handler}))
 


### PR DESCRIPTION
I got the error below while testing the Elasticsearch example in the readme.
Changing es-handler to a Var like the text-handler example fixes it.

```
2013-10-17 09:44:27,624 TRACE itsy.core: :extracting-urls
2013-10-17 09:44:27,648 ERROR itsy.core: Exception executing handler
clojure.lang.ArityException: Wrong number of args (1) passed to: user$es-handler
        at clojure.lang.AFn.throwArity(AFn.java:437)
        at clojure.lang.AFn.invoke(AFn.java:39)
        at itsy.core$crawl_page.invoke(core.clj:93)
        at itsy.core$worker_fn$worker_fn_STAR___3713.invoke(core.clj:134)
        at clojure.lang.AFn.run(AFn.java:24)
        at java.lang.Thread.run(Thread.java:724)
```
